### PR TITLE
Fixed empty nodes validation issue

### DIFF
--- a/io_scene_dae/export_dae.py
+++ b/io_scene_dae/export_dae.py
@@ -159,6 +159,13 @@ class DaeExporter:
         line = "{}{}".format(indent * "\t", text)
         self.sections[section].append(line)
 
+    def purge_empty_nodes(self):
+        sections = {}
+        for k, v in self.sections.items():
+            if not (len(v) == 2 and v[0][1:] == v[1][2:]):
+                sections[k] = v
+        self.sections = sections
+
     def export_image(self, image):
         img_id = self.image_cache.get(image)
         if img_id:
@@ -1706,7 +1713,7 @@ class DaeExporter:
                     for bone in node.data.bones:
                         if((bone.name.startswith("ctrl") and self.config["use_exclude_ctrl_bones"])):
                             continue
-                            
+
                         bone_name = self.skeleton_info[node]["bone_ids"][bone]
 
                         if (not (bone_name in xform_cache)):
@@ -1875,6 +1882,8 @@ class DaeExporter:
         self.writel(S_IMGS, 0, '</library_images>')
         self.writel(S_MATS, 0, '</library_materials>')
         self.writel(S_FX, 0, '</library_effects>')
+
+        self.purge_empty_nodes()
 
         if (self.config["use_anim"]):
             self.export_animations()


### PR DESCRIPTION
Fixes the issue described in #18.

About the check in the `if`, I know it's a bit unorthodox but it's fast and accurate (there cannot be any false positives that I can think of) without importing the `re` module.

I tested it on the Blender monkey (Suzanne) like @set-killer did and 

`xmllint --noout --schema collada_schema_1_4_1.xsd untitled.dae` 

validated it.

I also tested it on a more complex model ([this one](http://opengameart.org/content/mudeater-animated)) and everything went fine.

All code under GPLv2+, of course (this applies to all code I post on the `godotengine/collada-exporter` issue and PR trackers).