### PR TITLE
Removed useless unused vars

### DIFF
--- a/godot_export_manager.py
+++ b/godot_export_manager.py
@@ -50,9 +50,7 @@ class godot_export_manager(bpy.types.Panel):
     def draw(self, context):
         """ Draw function for all ui elements """
         layout = self.layout
-        split = self.layout.split()
         scene = bpy.data.scenes[0]
-        ob = context.object
         scene = context.scene
 
         row = layout.row()
@@ -61,13 +59,12 @@ class godot_export_manager(bpy.types.Panel):
 
         row = layout.row()
         col = row.column(align=True)
-        op = col.operator("scene.godot_add_objects_to_group",
-                          text="Add selected objects to Group",
-                          icon="COPYDOWN")
-
-        op = col.operator("scene.godot_delete_objects_from_group",
-                          text="Delete selected objects from Group",
-                          icon="PASTEDOWN")
+        col.operator("scene.godot_add_objects_to_group",
+                     text="Add selected objects to Group",
+                     icon="COPYDOWN")
+        col.operator("scene.godot_delete_objects_from_group",
+                     text="Delete selected objects from Group",
+                     icon="PASTEDOWN")
 
         row = layout.row()
         col = row.column()
@@ -127,8 +124,6 @@ class UI_List_Godot(bpy.types.UIList):
     """ Custom template_list look """
     def draw_item(self, context, layout, data, item, icon, active_data,
                   active_propname, index):
-        ob = data
-        slot = item
         col = layout.row(align=True)
 
         col.label(text=item.name, icon="GROUP")
@@ -309,8 +304,6 @@ class export_group(bpy.types.Operator):
             self.delete_object(group)
 
     def execute(self, context):
-
-        scene = context.scene
         group = context.scene.godot_export_groups
 
         if not group[self.idx].active and self.export_all:

--- a/io_scene_dae/__init__.py
+++ b/io_scene_dae/__init__.py
@@ -38,7 +38,7 @@ bl_info = {
 if "bpy" in locals():
     import imp
     if "export_dae" in locals():
-        imp.reload(export_dae)
+        imp.reload(export_dae)  # noqa
 
 
 class ExportDAE(bpy.types.Operator, ExportHelper):

--- a/io_scene_dae/export_dae.py
+++ b/io_scene_dae/export_dae.py
@@ -580,9 +580,6 @@ class DaeExporter:
         if armature is not None:
             si = self.skeleton_info[armature]
 
-        has_uv = False
-        has_uv2 = False
-        has_weights = armature is not None
         has_tangents = self.config["use_tangent_arrays"]  # could detect..
         has_colors = len(mesh.vertex_colors)
         mat_assign = []
@@ -673,7 +670,6 @@ class DaeExporter:
 
                 if armature is not None:
                     wsum = 0.0
-                    zero_bones = []
 
                     for vg in mv.groups:
                         if vg.group >= len(node.vertex_groups):
@@ -1718,7 +1714,6 @@ class DaeExporter:
         frame_orig = self.scene.frame_current
 
         frame_len = 1.0 / self.scene.render.fps
-        frame_total = end - start + 1
         frame_sub = 0
         if (start > 0):
             frame_sub = start * frame_len


### PR DESCRIPTION
I tested both plugins (I diffed the same exported models and compared some screenshots) and they work with the modifications. The `noqa` line is to tell flake8 to ignore that line (since it's not wrong to use a bare name with `imp.reload`, but of course that's not the general rule).

And now we are at 100% flake8 compliancy :tada: 