### PR TITLE
Fix for issue #35 (readme doesn't mention Godot Export Manager)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ format viable for importing meshes into game engines such as
    scripts/addons folder on your system (you should see other io_scene_*
    folders there from other addons). Copy the entire dir and not just its
    contents.
-2. Go to the Blender settings and enable the "Better Collada" plugin.
+2. Go to the Blender settings and enable the "Better Collada Exporter" plugin.
 3. Enjoy full-featured Collada export.
+4. (optional) Copy the `godot_export_manager.py` script to the scripts/addons folder.
+5. (optional) Enable the "Godot Export Manager" plugin.
 
 If you find bugs or want to suggest improvements, please open an issue on the
 upstream [GitHub repository](https://github.com/godotengine/collada-exporter).


### PR DESCRIPTION
Added two lines regarding the "Godot Export Manager" in README.md.