### PR TITLE
Added flag to enable/disable exporting of shape keys.

### DIFF
--- a/io_scene_dae/__init__.py
+++ b/io_scene_dae/__init__.py
@@ -133,6 +133,12 @@ class ExportDAE(bpy.types.Operator, ExportHelper):
         default=6.0,
         )
 
+    use_shape_key_export = BoolProperty(
+        name="Shape Keys",
+        description="Export shape keys for selected objects.",
+        default=False,
+        )
+
     use_metadata = BoolProperty(
         name="Use Metadata",
         default=True,

--- a/io_scene_dae/export_dae.py
+++ b/io_scene_dae/export_dae.py
@@ -388,7 +388,7 @@ class DaeExporter:
             return self.mesh_cache[mesh]
 
         if (skeyindex == -1 and mesh.shape_keys is not None and len(
-                mesh.shape_keys.key_blocks)):
+                mesh.shape_keys.key_blocks) and self.config["use_shape_key_export"]):
             values = []
             morph_targets = []
             md = None


### PR DESCRIPTION
Simple flag for consistency since there are already flags which allow you to ignore animation, ect., and since shape keys can't be quite tricky to work with.