### PR TITLE
Fixed order of properties

### DIFF
--- a/io_scene_dae/__init__.py
+++ b/io_scene_dae/__init__.py
@@ -124,6 +124,12 @@ class ExportDAE(bpy.types.Operator, ExportHelper):
         default=True,
         )
 
+    use_shape_key_export = BoolProperty(
+        name="Shape Keys",
+        description="Export shape keys for selected objects.",
+        default=False,
+        )
+		
     anim_optimize_precision = FloatProperty(
         name="Precision",
         description=("Tolerence for comparing double keyframes "
@@ -131,12 +137,6 @@ class ExportDAE(bpy.types.Operator, ExportHelper):
         min=1, max=16,
         soft_min=1, soft_max=16,
         default=6.0,
-        )
-
-    use_shape_key_export = BoolProperty(
-        name="Shape Keys",
-        description="Export shape keys for selected objects.",
-        default=False,
         )
 
     use_metadata = BoolProperty(


### PR DESCRIPTION
Changed the order of the properties to put shape key export toggle above the anim precision slider. Looks better. Meant to send it like this initially, but accidentally sent the wrong version.