### PR TITLE
Added basic functionality to move objects to center on export per group

### DIFF
--- a/godot_export_manager.py
+++ b/godot_export_manager.py
@@ -106,6 +106,7 @@ class godot_export_manager(bpy.types.Panel):
             row = layout.row()
             col = row.column()
 
+            col.prop(group, "use_move_to_center")
             col.prop(group, "use_include_particle_duplicates")
             col.prop(group, "use_mesh_modifiers")
             col.prop(group, "use_tangent_arrays")
@@ -365,6 +366,9 @@ class export_group(bpy.types.Operator):
                 else:
                     bpy.data.objects[object.name].select = True
 
+            if group[self.idx].use_move_to_center:
+                bpy.ops.object.location_clear()
+
             bpy.ops.object.transform_apply(location=group[self.idx].apply_loc,
                                            rotation=group[self.idx].apply_rot,
                                            scale=group[self.idx].apply_scale)
@@ -519,6 +523,9 @@ class godot_export_groups(bpy.types.PropertyGroup):
                                 options={"HIDDEN"})
     use_include_particle_duplicates = BoolProperty(
         name="Include Particle Duplicates", default=True)
+
+    use_move_to_center = BoolProperty(
+        name="Move Objects to Center", default=False)
 
 
 def register():


### PR DESCRIPTION
This adds a check box to the export manager that will move each object in a group to the center before exporting it. This functionality seemed like the best way to allow for multiple assets to be modeled in a single .blend file while still being able to export them as if they were their own file with their own 0,0,0 origin.

In my test cases, each group had multiple objects, but they all shared an origin, so every resulting collada file had objects that were sitting at the origin.

functionality implemented is standard bpy.ops.object.location_clear()