### PR TITLE
Fix face material lookup

### DIFF
--- a/io_scene_dae/export_dae.py
+++ b/io_scene_dae/export_dae.py
@@ -571,8 +571,8 @@ class DaeExporter:
                 surface_indices[f.material_index] = []
 
                 try:
-                    # TODO: Review, understand why it throws
-                    mat = mesh.materials[f.material_index]
+                    # Throws if the mesh has no materials, ignore it
+                    mat = node.material_slots[f.material_index].material
                 except:
                     mat = None
 


### PR DESCRIPTION
The current exporter looks for materials in the mesh data block. In Blender materials can be either linked to the object or data which can create some confusion. Most of the time current version works, but it can fail in certain cases. The correct way is to use the face material_index to index into the material_slots-array.  This should not break anything, but more testing could be useful.

I attached an "exportbug.zip" file which demonstrates the problem with Godot 3.0. If you export the .blend using the current addon you should notice that the cube has a red material in Godot instead of green despite both being green in Blender. Apply the patch, export, reimport and the cube should now be green and correct (remember to restart Blender to make sure the plugin is reloaded).

[exportbug.zip](https://github.com/godotengine/collada-exporter/files/1835135/exportbug.zip)
