### PR TITLE
* fix for bug in animation clip export due to lag in drivers update

### DIFF
--- a/io_scene_dae/export_dae.py
+++ b/io_scene_dae/export_dae.py
@@ -1666,7 +1666,12 @@ class DaeExporter:
         tcn = []
         xform_cache = {}
         blend_cache = {}
-
+        
+        # Blender updates drivers with one frame delay, causing the first frame to be wrong in the exported clip
+        # Jumping to the two first frames before exporting the clip fixes this issue
+        self.scene.frame_set(start)
+        self.scene.frame_set(start + 1)
+        
         # Change frames first, export objects last, boosts performance
         for t in range(start, end + 1):
             self.scene.frame_set(t)


### PR DESCRIPTION
Blender has one frame delay in updating drivers when playing an animation clip.

This causes a bug when exporting animation clips with drivers, the transformation of some bones in the first frame can be off, and that can lead to a staggered animation loop.

This change fixes the issue by jumping to the first two frames of the animation clip just before exporting the clip, allowing Blender to initialize the drivers correctly.