### PR TITLE
Set to 'object' mode before exporting

### DIFF
--- a/io_scene_dae/export_dae.py
+++ b/io_scene_dae/export_dae.py
@@ -1865,6 +1865,9 @@ class DaeExporter:
         self.writel(S_ANIM, 0, "</library_animations>")
 
     def export(self):
+
+        bpy.ops.object.mode_set(mode = 'OBJECT')
+        
         self.writel(S_GEOM, 0, "<library_geometries>")
         self.writel(S_CONT, 0, "<library_controllers>")
         self.writel(S_CAMS, 0, "<library_cameras>")


### PR DESCRIPTION
Shape keys remain static in edit mode when weighting is adjusted causing multiple shape keys of the same geometry. Also some animations won't work and other problems in edit mode. Edit mode is not restored after export so the user will have their workspace mode altered. https://github.com/godotengine/collada-exporter/issues/93