### PR TITLE
Fixed multiple actions issue

### DIFF
--- a/io_scene_dae/export_dae.py
+++ b/io_scene_dae/export_dae.py
@@ -1803,6 +1803,18 @@ class DaeExporter:
                 if (self.config["use_anim_skip_noexp"] and
                         x.name.endswith("-noexp")):
                     continue
+                    
+                # Before get anim keys, select current action with current strip
+                ob = bpy.context.object
+                ad = ob.animation_data
+                if ad:
+                    for i, track in enumerate(ad.nla_tracks):
+                        # nla track is current action?
+                        if x in list(map(lambda x:x.action, track.strips.values())):
+                            track.select = True
+                            track.is_solo = True
+                            ad.nla_tracks.active = track
+                            break
 
                 bones = []
                 # Find bones used


### PR DESCRIPTION
When working with multiple actions/nla tracks, we have an issue with when exporting animations.
In the target DAE file, all animations will have the same frames limited with original lenght.

Example of working animations:
![NLA_EDITOR](https://user-images.githubusercontent.com/1191611/54494584-b045eb80-48ba-11e9-8c7a-55a6fd4eb5fb.png)

This PR fixes this issue.

My enviroment:
- Blender 2.79
- Linux Mint 19.1
- Python 3.6.7

