### PR TITLE
Adds custom properties for materials and geometries

### DIFF
--- a/io_scene_dae/export_dae.py
+++ b/io_scene_dae/export_dae.py
@@ -376,6 +376,19 @@ class DaeExporter:
         self.writel(S_MATS, 1, "<material id=\"{}\" name=\"{}\">".format(
             matid, material.name))
         self.writel(S_MATS, 2, "<instance_effect url=\"#{}\"/>".format(fxid))
+
+        # Export custom properties
+        if len(material.keys()) > 1:
+            self.writel(S_MATS, 2, "<extra>")
+            self.writel(S_MATS, 3, "<technique profile=\"blender\">")
+            self.writel(S_MATS, 4, "<custom_properties>")
+            for K in material.keys():
+                if K not in '_RNA_UI':
+                    self.writel(S_MATS, 5, "<param name=\"{}\" type=\"string\">{}".format(K, material[K]) + "</param>")
+            self.writel(S_MATS, 4, "</custom_properties>")
+            self.writel(S_MATS, 3, "</technique>")
+            self.writel(S_MATS, 2, "</extra>")
+
         self.writel(S_MATS, 1, "</material>")
 
         self.material_cache[material] = matid
@@ -675,6 +688,19 @@ class DaeExporter:
         self.writel(
             S_GEOM, 1, "<geometry id=\"{}\" name=\"{}\">".format(
                 meshid, name_to_use))
+
+
+        # Export custom properties
+        if len(node.keys()) > 1:
+            self.writel(S_GEOM, 2, "<extra>")
+            self.writel(S_GEOM, 3, "<technique profile=\"blender\">")
+            self.writel(S_GEOM, 4, "<custom_properties>")
+            for K in node.keys():
+                if K not in '_RNA_UI':
+                    self.writel(S_GEOM, 5, "<param name=\"{}\" type=\"string\">{}".format(K, node[K]) + "</param>")
+            self.writel(S_GEOM, 4, "</custom_properties>")
+            self.writel(S_GEOM, 3, "</technique>")
+            self.writel(S_GEOM, 2, "</extra>")
 
         self.writel(S_GEOM, 2, "<mesh>")
 


### PR DESCRIPTION
Closes #77

The "blender" profile is used to included a <custom_properties> tag filled with <param name="xxx" type="string">yyy</param> where xxx is the blender custom property name and yyy the value as text. No further value conversion is done.