### PR TITLE
using node active material

### DIFF
--- a/io_scene_dae/export_dae.py
+++ b/io_scene_dae/export_dae.py
@@ -596,6 +596,9 @@ class DaeExporter:
                     mat = mesh.materials[f.material_index]
                 except:
                     mat = None
+                    
+                if mat is None:
+                    mat = node.active_material
 
                 if (mat is not None):
                     materials[f.material_index] = self.export_material(


### PR DESCRIPTION
In Blender one can assign a material to a node instead of the mesh.
The collada exporter should be extended with this situation.

Also, using node active material if no mesh material is found.
