### PR TITLE
Include closed spline indicator based on curve.spline.use_cyclic_u state

### DIFF
--- a/io_scene_dae/export_dae.py
+++ b/io_scene_dae/export_dae.py
@@ -1370,7 +1370,8 @@ class DaeExporter:
         self.writel(
             S_GEOM, 1, "<geometry id=\"{}\" name=\"{}\">".format(
                 splineid, curve.name))
-        self.writel(S_GEOM, 2, "<spline closed=\"0\">")
+        self.writel(S_GEOM, 2, "<spline closed=\"{}\">".format(
+                "true" if curve.splines and curve.splines[0].use_cyclic_u else "false"))
 
         points = []
         interps = []


### PR DESCRIPTION
While looking into https://github.com/godotengine/godot/issues/16658 I noticed this exporter assumes all splines are open.

This change checks the `use_cyclic_u` of the curve's first spline to determine whether a curve should be open or closed.