### PR TITLE
Fix Python 3.12 compatibility by replacing deprecated `imp` usage

### DIFF
--- a/io_scene_dae/__init__.py
+++ b/io_scene_dae/__init__.py
@@ -35,9 +35,9 @@ bl_info = {
     "category": "Import-Export"}
 
 if "bpy" in locals():
-    import imp
+    import importlib
     if "export_dae" in locals():
-        imp.reload(export_dae)  # noqa
+        importlib.reload(export_dae)  # noqa
 
 
 class CE_OT_export_dae(bpy.types.Operator, ExportHelper):


### PR DESCRIPTION
See https://docs.python.org/3/library/imp.html and https://docs.python.org/3/whatsnew/3.12.html#whatsnew312-removed-imp.

- This closes https://github.com/godotengine/collada-exporter/issues/137.